### PR TITLE
feat: Add new Button and Alert UI components

### DIFF
--- a/app/components/UiDemo.tsx
+++ b/app/components/UiDemo.tsx
@@ -3,8 +3,123 @@ import React, { useState } from 'react';
 import { Progress } from '@/app/components/ui/Progress';
 import { Breadcrumb } from '@/app/components/ui/Breadcrumb';
 import { Modal } from './ui/Modal';
-import { Home, AlertTriangle, Info } from 'lucide-react';
+import Button from '@/app/components/ui/button';
+import Alert from '@/app/components/ui/alert';
+import { Home, AlertTriangle, Info, Smile, Meh, Frown, Bell, Loader2, CheckCircle, XCircle } from 'lucide-react';
 import ModalContent from './examples/ModalContent';
+
+const ButtonShowcase: React.FC = () => {
+  return (
+    <div className="space-y-4">
+      <div>
+        <h4 className="text-md font-medium mb-2">Variants</h4>
+        <div className="flex flex-wrap gap-2">
+          <Button variant="primary">Primary</Button>
+          <Button variant="secondary">Secondary</Button>
+          <Button variant="outline">Outline</Button>
+          <Button variant="ghost">Ghost</Button>
+          <Button variant="link">Link</Button>
+        </div>
+      </div>
+      <div>
+        <h4 className="text-md font-medium mb-2">Sizes</h4>
+        <div className="flex flex-wrap gap-2 items-center">
+          <Button variant="primary" size="sm">Small</Button>
+          <Button variant="primary" size="md">Medium</Button>
+          <Button variant="primary" size="lg">Large</Button>
+        </div>
+      </div>
+      <div>
+        <h4 className="text-md font-medium mb-2">With Icons</h4>
+        <div className="flex flex-wrap gap-2">
+          <Button variant="primary" icon={<Smile />} iconPosition="left">
+            Icon Left
+          </Button>
+          <Button variant="secondary" icon={<Meh />} iconPosition="right">
+            Icon Right
+          </Button>
+        </div>
+      </div>
+      <div>
+        <h4 className="text-md font-medium mb-2">States</h4>
+        <div className="flex flex-wrap gap-2">
+          <Button variant="primary" isLoading>
+            Loading
+          </Button>
+          <Button variant="primary" disabled>
+            Disabled
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const AlertShowcase: React.FC = () => {
+  const [isSuccessAlertVisible, setIsSuccessAlertVisible] = useState(true);
+  const [isErrorAlertVisible, setIsErrorAlertVisible] = useState(true);
+  const [isWarningAlertVisible, setIsWarningAlertVisible] = useState(true);
+  const [isInfoAlertVisible, setIsInfoAlertVisible] = useState(true);
+  const [isCustomAlertVisible, setIsCustomAlertVisible] = useState(true);
+
+  const resetAlerts = () => {
+    setIsSuccessAlertVisible(true);
+    setIsErrorAlertVisible(true);
+    setIsWarningAlertVisible(true);
+    setIsInfoAlertVisible(true);
+    setIsCustomAlertVisible(true);
+  };
+
+  return (
+    <div className="space-y-4">
+      {isSuccessAlertVisible && (
+        <Alert
+          variant="success"
+          title="Success!"
+          message="Your profile has been updated successfully."
+          onClose={() => setIsSuccessAlertVisible(false)}
+        />
+      )}
+      {isErrorAlertVisible && (
+        <Alert
+          variant="error"
+          title="Error!"
+          message="Failed to upload file. Please try again."
+          onClose={() => setIsErrorAlertVisible(false)}
+        />
+      )}
+      {isWarningAlertVisible && (
+        <Alert
+          variant="warning"
+          title="Warning"
+          message="Your session is about to expire in 5 minutes."
+          onClose={() => setIsWarningAlertVisible(false)}
+        />
+      )}
+      {isInfoAlertVisible && (
+        <Alert
+          variant="info"
+          title="Information"
+          message="A new software update is available for download."
+          onClose={() => setIsInfoAlertVisible(false)}
+        />
+      )}
+      {isCustomAlertVisible && (
+        <Alert
+          variant="info" // Base variant for styling, can be overridden by className
+          title="Custom Alert"
+          message="This alert uses a custom icon and styling."
+          icon={<Bell className="h-5 w-5 text-purple-600" />}
+          className="bg-purple-100 border-purple-400 text-purple-700"
+          onClose={() => setIsCustomAlertVisible(false)}
+        />
+      )}
+      {!isSuccessAlertVisible && !isErrorAlertVisible && !isWarningAlertVisible && !isInfoAlertVisible && !isCustomAlertVisible && (
+        <Button onClick={resetAlerts}>Reset Alerts</Button>
+      )}
+    </div>
+  );
+};
 
 export const UIComponentDemo: React.FC = () => {
   const [isRewardModalOpen, setIsRewardModalOpen] = useState(false);
@@ -225,6 +340,18 @@ export const UIComponentDemo: React.FC = () => {
 
         {/* error */}
 
+      </div>
+
+      {/* Button Demo */}
+      <div>
+        <h3 className="text-lg font-semibold mb-2">Buttons</h3>
+        <ButtonShowcase />
+      </div>
+
+      {/* Alert Demo */}
+      <div>
+        <h3 className="text-lg font-semibold mb-2">Alerts</h3>
+        <AlertShowcase />
       </div>
     </div>
   );

--- a/app/components/ui/alert.tsx
+++ b/app/components/ui/alert.tsx
@@ -1,0 +1,78 @@
+import React, { useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { CheckCircle, XCircle, AlertTriangle, Info, X } from 'lucide-react';
+
+interface AlertProps {
+  variant?: 'success' | 'error' | 'warning' | 'info';
+  title?: string;
+  message: string | React.ReactNode;
+  icon?: React.ReactNode;
+  onClose?: () => void;
+  className?: string;
+}
+
+const Alert: React.FC<AlertProps> = ({
+  variant = 'info',
+  title,
+  message,
+  icon,
+  onClose,
+  className = '',
+}) => {
+  const [isVisible, setIsVisible] = useState(true);
+
+  const defaultIcons = {
+    success: <CheckCircle className="h-5 w-5" />,
+    error: <XCircle className="h-5 w-5" />,
+    warning: <AlertTriangle className="h-5 w-5" />,
+    info: <Info className="h-5 w-5" />,
+  };
+
+  const variantStyles = {
+    success: 'bg-green-100 border-green-400 text-green-700',
+    error: 'bg-red-100 border-red-400 text-red-700',
+    warning: 'bg-yellow-100 border-yellow-400 text-yellow-700',
+    info: 'bg-blue-100 border-blue-400 text-blue-700',
+  };
+
+  const handleClose = () => {
+    if (onClose) {
+      onClose();
+    }
+    setIsVisible(false);
+  };
+
+  const selectedIcon = icon || defaultIcons[variant];
+
+  return (
+    <AnimatePresence>
+      {isVisible && (
+        <motion.div
+          initial={{ opacity: 0, y: -20 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, x: '-100%' }}
+          transition={{ duration: 0.3 }}
+          className={`border-l-4 p-4 rounded-md shadow-md flex ${variantStyles[variant]} ${className}`}
+          role="alert"
+        >
+          <div className="flex-shrink-0 mr-3">{selectedIcon}</div>
+          <div className="flex-grow">
+            {title && <h5 className="font-bold mb-1">{title}</h5>}
+            <div>{message}</div>
+          </div>
+          {onClose && (
+            <button
+              onClick={handleClose}
+              className="ml-auto pl-3 -mr-1 -my-1"
+              aria-label="Close alert"
+            >
+              <X className="h-5 w-5" />
+            </button>
+          )}
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+};
+
+export default Alert;

--- a/app/components/ui/button.tsx
+++ b/app/components/ui/button.tsx
@@ -1,0 +1,72 @@
+import React, { MouseEventHandler } from 'react';
+import { motion } from 'framer-motion';
+import { Loader2 } from 'lucide-react';
+
+interface ButtonProps {
+  variant?: 'primary' | 'secondary' | 'outline' | 'ghost' | 'link';
+  size?: 'sm' | 'md' | 'lg';
+  isLoading?: boolean;
+  disabled?: boolean;
+  onClick?: MouseEventHandler<HTMLButtonElement>;
+  children: React.ReactNode;
+  icon?: React.ReactNode;
+  iconPosition?: 'left' | 'right';
+  className?: string;
+}
+
+const Button: React.FC<ButtonProps> = ({
+  variant = 'primary',
+  size = 'md',
+  isLoading = false,
+  disabled = false,
+  onClick,
+  children,
+  icon,
+  iconPosition = 'left',
+  className = '',
+}) => {
+  const baseStyles =
+    'inline-flex items-center justify-center rounded-md font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none';
+
+  const variantStyles = {
+    primary: 'bg-primary text-primary-foreground hover:bg-primary/90',
+    secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+    outline:
+      'border border-input bg-transparent hover:bg-accent hover:text-accent-foreground',
+    ghost: 'hover:bg-accent hover:text-accent-foreground',
+    link: 'text-primary underline-offset-4 hover:underline',
+  };
+
+  const sizeStyles = {
+    sm: 'h-9 px-3 rounded-md',
+    md: 'h-10 px-4 py-2 rounded-md',
+    lg: 'h-11 px-8 rounded-md',
+  };
+
+  const iconSize = {
+    sm: 'h-4 w-4',
+    md: 'h-5 w-5',
+    lg: 'h-6 w-6',
+  };
+
+  return (
+    <motion.button
+      whileHover={{ scale: 1.05 }}
+      whileTap={{ scale: 0.95 }}
+      className={`${baseStyles} ${variantStyles[variant]} ${sizeStyles[size]} ${className}`}
+      onClick={onClick}
+      disabled={disabled || isLoading}
+    >
+      {isLoading && <Loader2 className={`animate-spin ${iconSize[size]} mr-2`} />}
+      {icon && iconPosition === 'left' && !isLoading && (
+        <span className={`mr-2 ${iconSize[size]}`}>{icon}</span>
+      )}
+      {children}
+      {icon && iconPosition === 'right' && !isLoading && (
+        <span className={`ml-2 ${iconSize[size]}`}>{icon}</span>
+      )}
+    </motion.button>
+  );
+};
+
+export default Button;


### PR DESCRIPTION
This commit introduces two new reusable UI components: Button and Alert.

Button Component (`app/components/ui/button.tsx`):
- Supports multiple variants: 'primary', 'secondary', 'outline', 'ghost', 'link'.
- Customizable sizes: 'sm', 'md', 'lg'.
- Includes `isLoading` and `disabled` states.
- Allows for optional icons (Lucide React) with 'left' or 'right' positioning.
- Styled with Tailwind CSS and includes Framer Motion for interactions.

Alert Component (`app/components/ui/alert.tsx`):
- Supports variants: 'success', 'error', 'warning', 'info'.
- Can display a title and message.
- Allows for custom icons (defaults to variant-specific Lucide React icons).
- Supports dismissible functionality with an `onClose` handler.
- Styled with Tailwind CSS and includes Framer Motion for animations.

Both components have been integrated into `app/components/UiDemo.tsx` for demonstration purposes, showcasing their various features and states. The individual showcase code within the component files has been removed.